### PR TITLE
Fix documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.0.3-alpha
+
+- Enhancements
+
+  - Properly version the package.
+
+- Bug fixes
+  - Fix readme.
+
 ## v0.0.1 (2021-04-10)
 
 - Enhancements

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A way to add contexts to function calls. Given:
 defmodule MyModule do
   use Oriza.Context
 
-  @context admin: [:read, :write]
+  context(:do_something, [:arg], [admin: [:read, :write]])
   def do_something(arg), do: arg
 end
 ```
@@ -14,8 +14,8 @@ end
 Creates the following additional function definition:
 
 ```elixir
-def do_something(context, arg) do
-  with :ok <- check_context(context) do
+def do_something(user_context, arg) do
+  with :ok <- check_context(user_context, %Oriza.Context{keys: [admin: [:read, :write]]}) do
     do_something(arg)
   else
     _ -> {:error, "access denied"}
@@ -24,17 +24,14 @@ end
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `oriza` to your list of dependencies in `mix.exs`:
+Oriza can be added as a project dependency:
 
 ```elixir
 def deps do
   [
-    {:oriza, "~> 0.0.1"}
+    {:oriza, "~> 0.0.3-alpha"}
   ]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/oriza](https://hexdocs.pm/oriza).
+After adding the dependency, modules can `use Oriza`, which will give access to the `context` macro.

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Oriza.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/rmparr/oriza"
-  @version "0.0.2"
+  @version "0.0.3-alpha"
 
   def project do
     [


### PR DESCRIPTION
The readme didn't properly capture the macro usage.

Also, this really is an alpha, so it should be called such.