### PR TITLE
Add git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ end
 ```
 
 After adding the dependency, modules can `use Oriza`, which will give access to the `context` macro.
+
+## Contributing
+
+### Git Hooks
+
+GitHub Actions is going to run all of this anyway, so why not check before?
+
+To remove any existing hooks and symlink the repo git hooks, run `mix run scripts/symlink_git_hooks.exs` from the command line.

--- a/git_hooks/pre-commit.sh
+++ b/git_hooks/pre-commit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd `git rev-parse --show-toplevel`
+mix format --check-formatted
+if [ $? == 1 ]; then
+  echo "commit failed due to format issues..."
+  exit 1
+fi

--- a/git_hooks/pre-push.sh
+++ b/git_hooks/pre-push.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euxo pipefail
+cd `git rev-parse --show-toplevel`
+
+mix clean
+mix format --check-formatted
+mix coveralls
+mix credo -a --strict
+mix dialyzer

--- a/scripts/symlink_git_hooks.exs
+++ b/scripts/symlink_git_hooks.exs
@@ -1,0 +1,12 @@
+hooks = File.ls!("./git_hooks")
+
+for hook <- hooks do
+  hook = String.replace_trailing(hook, ".sh", "")
+  File.rm(".git/hooks/#{hook}")
+
+  if File.ln_s("../../git_hooks/#{hook}.sh", ".git/hooks/#{hook}") == :ok do
+    IO.puts("Symlinked #{hook}.")
+  else
+    IO.puts("Couldn't symlink #{hook}.")
+  end
+end


### PR DESCRIPTION
In an effort to maintain code conventions, formatting, and coverage, we want to run a few tasks before committing or pushing code.

This PR includes 2 shell scripts, and a small script to symlink them to the developer's local git repository.

None of this is necessary, as the same tasks get run on CI, but they will finish faster on a developer machine than it will take to spin up a Docker contain, so it should save time.