### PR TITLE
Add Elixir 1.12 Otp 24 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     name: OTP ${{ matrix.otp }} | Elixir ${{ matrix.elixir }} | OS ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
-        otp: ['22', '23']
-        elixir: ['1.10', '1.11']
+        os: [ubuntu-latest]
+        otp: ['22', '23', '24']
+        elixir: ['1.10', '1.11', '1.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.3-otp-23
-erlang 23.2.1
+elixir 1.12.0-otp-24
+erlang 24.0


### PR DESCRIPTION
Elixir 1.12 and OTP 24 have been released. This PR adds them to the CI pipeline, and bumps the project to use them for development.